### PR TITLE
Replaced UUIDs with unsigned longs to improve speed and file size

### DIFF
--- a/src/Converters/JSONConverter.cpp
+++ b/src/Converters/JSONConverter.cpp
@@ -112,7 +112,7 @@ const char* JSONConverter::convert(odict::SearchResult *searchResult) {
     while (result != results.end()) {
         pt::ptree entry_node;
 
-        entry_node.put("id", (*result)->id()->str());
+        entry_node.put("id", (*result)->id());
         entry_node.put("term", (*result)->term()->str());
 
         this->add_etymologies(&entry_node, (*result)->etymologies());

--- a/src/Converters/JSONConverter.cpp
+++ b/src/Converters/JSONConverter.cpp
@@ -28,7 +28,7 @@ void JSONConverter::add_groups(pt::ptree *root, const Vector<Offset<Group>> *gro
 
         pt::ptree group_node;
 
-        group_node.put("id", group->id()->str());
+        group_node.put("id", group->id());
 
         if (group->description()->str().length() > 0)
             group_node.put("description", group->description()->str());
@@ -55,7 +55,7 @@ void JSONConverter::add_usages(pt::ptree *root, const Vector<Offset<Usage>> *usa
 
         pt::ptree usage_node;
 
-        usage_node.put("id", usage->id()->str());
+        usage_node.put("id", usage->id());
 
         if (usage->pos()->str().length() > 0)
             usage_node.put("pos", usage->pos()->str());
@@ -83,7 +83,7 @@ void JSONConverter::add_etymologies(pt::ptree *root, const Vector<Offset<Etymolo
 
         pt::ptree ety_node;
 
-        ety_node.put("id", etymology->id()->str());
+        ety_node.put("id", etymology->id());
 
         if (etymology->description()->str().length() > 0)
             ety_node.put("description", etymology->description()->str());
@@ -138,6 +138,9 @@ const char* JSONConverter::convert(odict::SearchResult *searchResult) {
 const char* JSONConverter::convert(Entry *entry) {
     pt::ptree root;
     stringstream ss;
+
+    root.put("id", entry->id());
+    root.put("term", entry->term()->str());
 
     this->add_etymologies(&root, entry->etymologies());
 

--- a/src/Dictionary/DictionaryWriter.cpp
+++ b/src/Dictionary/DictionaryWriter.cpp
@@ -111,17 +111,18 @@ Offset<Vector<Offset<String>>> DictionaryWriter::get_definitions(xml_node<> *nod
 Offset<Vector<Offset<Group>>> DictionaryWriter::get_groups(xml_node<> *usage_node) {
     xml_node<> *current_group = usage_node->first_node(NODE_GROUP);
     vector<Offset<Group>> groups = vector<Offset<Group>>();
-
+    unsigned long count = 0;
     while (current_group != 0) {
         string description = get_attribute_if_exists(current_group, ATTR_DESCRIPTION);
 
         groups.push_back(CreateGroup(
                 builder,
-                this->get_uuid_string(),
+                count,
                 builder.CreateString(description),
                 this->get_definitions(current_group)
         ));
 
+        count++;
         current_group = current_group->next_sibling(NODE_GROUP);
     }
 
@@ -131,6 +132,7 @@ Offset<Vector<Offset<Group>>> DictionaryWriter::get_groups(xml_node<> *usage_nod
 Offset<Vector<Offset<Etymology>>> DictionaryWriter::get_etymologies(xml_node<> *entry_node) {
     xml_node<> *current_ety = entry_node->first_node(NODE_ETY);
     vector<Offset<Etymology>> etymologies = vector<Offset<Etymology>>();
+    unsigned int count = 0;
 
     while (current_ety != 0) {
         string description = get_attribute_if_exists(current_ety, ATTR_DESCRIPTION);
@@ -138,11 +140,12 @@ Offset<Vector<Offset<Etymology>>> DictionaryWriter::get_etymologies(xml_node<> *
 
         etymologies.push_back(CreateEtymology(
                 builder,
-                this->get_uuid_string(),
+                count,
                 builder.CreateString(description),
                 usages
         ));
 
+        count++;
         current_ety = current_ety->next_sibling(NODE_ETY);
     }
 
@@ -157,6 +160,7 @@ Offset<Vector<Offset<Etymology>>> DictionaryWriter::get_etymologies(xml_node<> *
 Offset<Vector<Offset<Usage>>> DictionaryWriter::get_usages(xml_node<> *ety_node) {
     xml_node<> *current_usage = ety_node->first_node(NODE_USAGE);
     vector<Offset<Usage>> usages = vector<Offset<Usage>>();
+    unsigned long count = 0;
 
     while (current_usage != 0) {
         string part_of_speech = get_attribute_if_exists(current_usage, ATTR_PART_OF_SPEECH);
@@ -165,12 +169,13 @@ Offset<Vector<Offset<Usage>>> DictionaryWriter::get_usages(xml_node<> *ety_node)
 
         usages.push_back(CreateUsage(
                 builder,
-                this->get_uuid_string(),
+                count,
                 builder.CreateString(part_of_speech),
                 definitions,
                 groups
         ));
 
+        count++;
         current_usage = current_usage->next_sibling(NODE_USAGE);
     }
 

--- a/src/Dictionary/DictionaryWriter.cpp
+++ b/src/Dictionary/DictionaryWriter.cpp
@@ -1,5 +1,11 @@
 #include "DictionaryWriter.h"
 
+/**
+ * Returns an XML node attribute if it exists on the node
+ * @param node
+ * @param attribute
+ * @return
+ */
 string get_attribute_if_exists(xml_node<> *node, const char *attribute) {
     auto first_attr = node->first_attribute(attribute);
 
@@ -10,6 +16,30 @@ string get_attribute_if_exists(xml_node<> *node, const char *attribute) {
     }
 }
 
+
+/**
+ * Gets all of the entries in a dictionary node and returns them as a FlatBuffer object
+ * @param dictionary_node
+ * @return
+ */
+int entry_count(xml_node<> *dictionary_node) {
+    xml_node<> *current_entry = dictionary_node->first_node(NODE_ENTRY);
+    vector<Offset<Entry>> entries = vector<Offset<Entry>>();
+    int count;
+
+    while (current_entry != 0) {
+        count++;
+        current_entry = current_entry->next_sibling(NODE_ENTRY);
+    }
+
+    return count;
+}
+
+/**
+ * Counts the number of digits in a number
+ * @param x
+ * @return
+ */
 int num_digits(int32_t x)
 {
     if (x == INT_MIN) return 10 + 1;
@@ -147,25 +177,6 @@ Offset<Vector<Offset<Usage>>> DictionaryWriter::get_usages(xml_node<> *ety_node)
     return builder.CreateVector(usages);
 }
 
-
-/**
- * Gets all of the entries in a dictionary node and returns them as a FlatBuffer object
- * @param dictionary_node
- * @return
- */
-int entry_count(xml_node<> *dictionary_node) {
-    xml_node<> *current_entry = dictionary_node->first_node(NODE_ENTRY);
-    vector<Offset<Entry>> entries = vector<Offset<Entry>>();
-    int count;
-
-    while (current_entry != 0) {
-        count++;
-        current_entry = current_entry->next_sibling(NODE_ENTRY);
-    }
-
-    return count;
-}
-
 /**
  * Gets all of the entries in a dictionary node and returns them as a FlatBuffer object
  * @param dictionary_node
@@ -175,14 +186,14 @@ Offset<Vector<Offset<Entry>>> DictionaryWriter::get_entries(xml_node<> *dictiona
     xml_node<> *current_entry = dictionary_node->first_node(NODE_ENTRY);
     vector<Offset<Entry>> entries = vector<Offset<Entry>>();
 
-    int count = 0;
+    unsigned long count = 0;
     int total = entry_count(dictionary_node);
     int total_d = num_digits(total);
 
     while (current_entry != 0) {
         string term = get_attribute_if_exists(current_entry, ATTR_TERM);
         auto etymologies = this->get_etymologies(current_entry);
-        entries.push_back(CreateEntry(builder, this->get_uuid_string(), builder.CreateString(term), etymologies));
+        entries.push_back(CreateEntry(builder, count, builder.CreateString(term), etymologies));
         count++;
         current_entry = current_entry->next_sibling(NODE_ENTRY);
         cout << "\r" << setw(total_d) << right << count << " / " << setw(total_d) << left << total << " words processed" << flush;

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -40,7 +40,7 @@ table Entry {
 }
 
 table Dictionary {
-    id:ulong;
+    id:string;
     name:string;
     entries:[Entry];
 }

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -15,32 +15,32 @@ enum POS:byte {
 }
 
 table Etymology {
-    id:string;
+    id:ulong;
     description:string;
     usages:[Usage];
 }
 
 table Group {
-    id:string;
+    id:ulong;
     description:string;
     definitions:[string];
 }
 
 table Usage {
-    id:string;
+    id:ulong;
     pos:string;
     definitions:[string];
     groups:[Group];
 }
 
 table Entry {
-    id:string;
+    id:ulong;
     term:string (key);
     etymologies:[Etymology];
 }
 
 table Dictionary {
-    id:string;
+    id:ulong;
     name:string;
     entries:[Entry];
 }

--- a/src/schema_generated.h
+++ b/src/schema_generated.h
@@ -80,8 +80,8 @@ struct Etymology FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_DESCRIPTION = 6,
     VT_USAGES = 8
   };
-  const flatbuffers::String *id() const {
-    return GetPointer<const flatbuffers::String *>(VT_ID);
+  uint64_t id() const {
+    return GetField<uint64_t>(VT_ID, 0);
   }
   const flatbuffers::String *description() const {
     return GetPointer<const flatbuffers::String *>(VT_DESCRIPTION);
@@ -91,8 +91,7 @@ struct Etymology FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.Verify(id()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            VerifyOffset(verifier, VT_DESCRIPTION) &&
            verifier.Verify(description()) &&
            VerifyOffset(verifier, VT_USAGES) &&
@@ -105,8 +104,8 @@ struct Etymology FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct EtymologyBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
-    fbb_.AddOffset(Etymology::VT_ID, id);
+  void add_id(uint64_t id) {
+    fbb_.AddElement<uint64_t>(Etymology::VT_ID, id, 0);
   }
   void add_description(flatbuffers::Offset<flatbuffers::String> description) {
     fbb_.AddOffset(Etymology::VT_DESCRIPTION, description);
@@ -128,24 +127,24 @@ struct EtymologyBuilder {
 
 inline flatbuffers::Offset<Etymology> CreateEtymology(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> id = 0,
+    uint64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> description = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Usage>>> usages = 0) {
   EtymologyBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_usages(usages);
   builder_.add_description(description);
-  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Etymology> CreateEtymologyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *id = nullptr,
+    uint64_t id = 0,
     const char *description = nullptr,
     const std::vector<flatbuffers::Offset<Usage>> *usages = nullptr) {
   return schema::CreateEtymology(
       _fbb,
-      id ? _fbb.CreateString(id) : 0,
+      id,
       description ? _fbb.CreateString(description) : 0,
       usages ? _fbb.CreateVector<flatbuffers::Offset<Usage>>(*usages) : 0);
 }
@@ -156,8 +155,8 @@ struct Group FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_DESCRIPTION = 6,
     VT_DEFINITIONS = 8
   };
-  const flatbuffers::String *id() const {
-    return GetPointer<const flatbuffers::String *>(VT_ID);
+  uint64_t id() const {
+    return GetField<uint64_t>(VT_ID, 0);
   }
   const flatbuffers::String *description() const {
     return GetPointer<const flatbuffers::String *>(VT_DESCRIPTION);
@@ -167,8 +166,7 @@ struct Group FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.Verify(id()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            VerifyOffset(verifier, VT_DESCRIPTION) &&
            verifier.Verify(description()) &&
            VerifyOffset(verifier, VT_DEFINITIONS) &&
@@ -181,8 +179,8 @@ struct Group FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct GroupBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
-    fbb_.AddOffset(Group::VT_ID, id);
+  void add_id(uint64_t id) {
+    fbb_.AddElement<uint64_t>(Group::VT_ID, id, 0);
   }
   void add_description(flatbuffers::Offset<flatbuffers::String> description) {
     fbb_.AddOffset(Group::VT_DESCRIPTION, description);
@@ -204,24 +202,24 @@ struct GroupBuilder {
 
 inline flatbuffers::Offset<Group> CreateGroup(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> id = 0,
+    uint64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> description = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> definitions = 0) {
   GroupBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_definitions(definitions);
   builder_.add_description(description);
-  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Group> CreateGroupDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *id = nullptr,
+    uint64_t id = 0,
     const char *description = nullptr,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *definitions = nullptr) {
   return schema::CreateGroup(
       _fbb,
-      id ? _fbb.CreateString(id) : 0,
+      id,
       description ? _fbb.CreateString(description) : 0,
       definitions ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*definitions) : 0);
 }
@@ -233,8 +231,8 @@ struct Usage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_DEFINITIONS = 8,
     VT_GROUPS = 10
   };
-  const flatbuffers::String *id() const {
-    return GetPointer<const flatbuffers::String *>(VT_ID);
+  uint64_t id() const {
+    return GetField<uint64_t>(VT_ID, 0);
   }
   const flatbuffers::String *pos() const {
     return GetPointer<const flatbuffers::String *>(VT_POS);
@@ -247,8 +245,7 @@ struct Usage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.Verify(id()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            VerifyOffset(verifier, VT_POS) &&
            verifier.Verify(pos()) &&
            VerifyOffset(verifier, VT_DEFINITIONS) &&
@@ -264,8 +261,8 @@ struct Usage FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct UsageBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
-    fbb_.AddOffset(Usage::VT_ID, id);
+  void add_id(uint64_t id) {
+    fbb_.AddElement<uint64_t>(Usage::VT_ID, id, 0);
   }
   void add_pos(flatbuffers::Offset<flatbuffers::String> pos) {
     fbb_.AddOffset(Usage::VT_POS, pos);
@@ -290,27 +287,27 @@ struct UsageBuilder {
 
 inline flatbuffers::Offset<Usage> CreateUsage(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> id = 0,
+    uint64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> pos = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> definitions = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Group>>> groups = 0) {
   UsageBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_groups(groups);
   builder_.add_definitions(definitions);
   builder_.add_pos(pos);
-  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Usage> CreateUsageDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *id = nullptr,
+    uint64_t id = 0,
     const char *pos = nullptr,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *definitions = nullptr,
     const std::vector<flatbuffers::Offset<Group>> *groups = nullptr) {
   return schema::CreateUsage(
       _fbb,
-      id ? _fbb.CreateString(id) : 0,
+      id,
       pos ? _fbb.CreateString(pos) : 0,
       definitions ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*definitions) : 0,
       groups ? _fbb.CreateVector<flatbuffers::Offset<Group>>(*groups) : 0);
@@ -322,8 +319,8 @@ struct Entry FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_TERM = 6,
     VT_ETYMOLOGIES = 8
   };
-  const flatbuffers::String *id() const {
-    return GetPointer<const flatbuffers::String *>(VT_ID);
+  uint64_t id() const {
+    return GetField<uint64_t>(VT_ID, 0);
   }
   const flatbuffers::String *term() const {
     return GetPointer<const flatbuffers::String *>(VT_TERM);
@@ -339,8 +336,7 @@ struct Entry FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.Verify(id()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            VerifyOffsetRequired(verifier, VT_TERM) &&
            verifier.Verify(term()) &&
            VerifyOffset(verifier, VT_ETYMOLOGIES) &&
@@ -353,8 +349,8 @@ struct Entry FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct EntryBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
-    fbb_.AddOffset(Entry::VT_ID, id);
+  void add_id(uint64_t id) {
+    fbb_.AddElement<uint64_t>(Entry::VT_ID, id, 0);
   }
   void add_term(flatbuffers::Offset<flatbuffers::String> term) {
     fbb_.AddOffset(Entry::VT_TERM, term);
@@ -377,24 +373,24 @@ struct EntryBuilder {
 
 inline flatbuffers::Offset<Entry> CreateEntry(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> id = 0,
+    uint64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> term = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Etymology>>> etymologies = 0) {
   EntryBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_etymologies(etymologies);
   builder_.add_term(term);
-  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Entry> CreateEntryDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *id = nullptr,
+    uint64_t id = 0,
     const char *term = nullptr,
     const std::vector<flatbuffers::Offset<Etymology>> *etymologies = nullptr) {
   return schema::CreateEntry(
       _fbb,
-      id ? _fbb.CreateString(id) : 0,
+      id,
       term ? _fbb.CreateString(term) : 0,
       etymologies ? _fbb.CreateVector<flatbuffers::Offset<Etymology>>(*etymologies) : 0);
 }
@@ -405,8 +401,8 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_NAME = 6,
     VT_ENTRIES = 8
   };
-  const flatbuffers::String *id() const {
-    return GetPointer<const flatbuffers::String *>(VT_ID);
+  uint64_t id() const {
+    return GetField<uint64_t>(VT_ID, 0);
   }
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
@@ -416,8 +412,7 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_ID) &&
-           verifier.Verify(id()) &&
+           VerifyField<uint64_t>(verifier, VT_ID) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.Verify(name()) &&
            VerifyOffset(verifier, VT_ENTRIES) &&
@@ -430,8 +425,8 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct DictionaryBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
-    fbb_.AddOffset(Dictionary::VT_ID, id);
+  void add_id(uint64_t id) {
+    fbb_.AddElement<uint64_t>(Dictionary::VT_ID, id, 0);
   }
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(Dictionary::VT_NAME, name);
@@ -453,24 +448,24 @@ struct DictionaryBuilder {
 
 inline flatbuffers::Offset<Dictionary> CreateDictionary(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::String> id = 0,
+    uint64_t id = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Entry>>> entries = 0) {
   DictionaryBuilder builder_(_fbb);
+  builder_.add_id(id);
   builder_.add_entries(entries);
   builder_.add_name(name);
-  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Dictionary> CreateDictionaryDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const char *id = nullptr,
+    uint64_t id = 0,
     const char *name = nullptr,
     const std::vector<flatbuffers::Offset<Entry>> *entries = nullptr) {
   return schema::CreateDictionary(
       _fbb,
-      id ? _fbb.CreateString(id) : 0,
+      id,
       name ? _fbb.CreateString(name) : 0,
       entries ? _fbb.CreateVector<flatbuffers::Offset<Entry>>(*entries) : 0);
 }

--- a/src/schema_generated.h
+++ b/src/schema_generated.h
@@ -401,8 +401,8 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_NAME = 6,
     VT_ENTRIES = 8
   };
-  uint64_t id() const {
-    return GetField<uint64_t>(VT_ID, 0);
+  const flatbuffers::String *id() const {
+    return GetPointer<const flatbuffers::String *>(VT_ID);
   }
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
@@ -412,7 +412,8 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyField<uint64_t>(verifier, VT_ID) &&
+           VerifyOffset(verifier, VT_ID) &&
+           verifier.Verify(id()) &&
            VerifyOffset(verifier, VT_NAME) &&
            verifier.Verify(name()) &&
            VerifyOffset(verifier, VT_ENTRIES) &&
@@ -425,8 +426,8 @@ struct Dictionary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 struct DictionaryBuilder {
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_id(uint64_t id) {
-    fbb_.AddElement<uint64_t>(Dictionary::VT_ID, id, 0);
+  void add_id(flatbuffers::Offset<flatbuffers::String> id) {
+    fbb_.AddOffset(Dictionary::VT_ID, id);
   }
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(Dictionary::VT_NAME, name);
@@ -448,24 +449,24 @@ struct DictionaryBuilder {
 
 inline flatbuffers::Offset<Dictionary> CreateDictionary(
     flatbuffers::FlatBufferBuilder &_fbb,
-    uint64_t id = 0,
+    flatbuffers::Offset<flatbuffers::String> id = 0,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Entry>>> entries = 0) {
   DictionaryBuilder builder_(_fbb);
-  builder_.add_id(id);
   builder_.add_entries(entries);
   builder_.add_name(name);
+  builder_.add_id(id);
   return builder_.Finish();
 }
 
 inline flatbuffers::Offset<Dictionary> CreateDictionaryDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    uint64_t id = 0,
+    const char *id = nullptr,
     const char *name = nullptr,
     const std::vector<flatbuffers::Offset<Entry>> *entries = nullptr) {
   return schema::CreateDictionary(
       _fbb,
-      id,
+      id ? _fbb.CreateString(id) : 0,
       name ? _fbb.CreateString(name) : 0,
       entries ? _fbb.CreateVector<flatbuffers::Offset<Entry>>(*entries) : 0);
 }


### PR DESCRIPTION
It recently came to my attention that storing UUIDs for every etymology, usage, group, etc. was maybe not the *best* idea considering it grossly inflated the file size of compiled dictionaries and slowed down the DictionaryWriter to a crawl. This problem has been around since [December](https://github.com/odict/odict/commit/96d6541a82fb313697a14d7514f7d3277d527c54), so I'm pretty ashamed for just now realizing it. Will merge once the fix is complete.